### PR TITLE
feat(home): Adds home UI, viewmodel & command

### DIFF
--- a/lib/domain/models/user.dart
+++ b/lib/domain/models/user.dart
@@ -1,0 +1,21 @@
+// Copyright 2024 The Flutter team. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'user.freezed.dart';
+part 'user.g.dart';
+
+@freezed
+abstract class User with _$User {
+  const factory User({
+    /// The user's name.
+    required String name,
+
+    /// The user's picture URL.
+    required String picture,
+  }) = _User;
+
+  factory User.fromJson(Map<String, Object?> json) => _$UserFromJson(json);
+}

--- a/lib/ui/home/view_model/home_viewmodel.dart
+++ b/lib/ui/home/view_model/home_viewmodel.dart
@@ -1,0 +1,91 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:logging/logging.dart';
+
+import '../../../data/repositories/booking/booking_repository.dart';
+import '../../../data/repositories/user/user_repository.dart';
+import '../../../domain/models/booking/booking_summary.dart';
+import '../../../domain/models/user/user.dart';
+import '../../../utils/command.dart';
+import '../../../utils/result.dart';
+
+class HomeViewModel extends ChangeNotifier {
+  HomeViewModel({
+    required BookingRepository bookingRepository,
+    required UserRepository userRepository,
+  }) : _bookingRepository = bookingRepository,
+       _userRepository = userRepository {
+    load = Command0(_load)..execute();
+    deleteBooking = Command1(_deleteBooking);
+  }
+
+  final BookingRepository _bookingRepository;
+  final UserRepository _userRepository;
+  final _log = Logger('HomeViewModel');
+  List<BookingSummary> _bookings = [];
+  User? _user;
+
+  late Command0 load;
+  late Command1<void, int> deleteBooking;
+
+  List<BookingSummary> get bookings => _bookings;
+
+  User? get user => _user;
+
+  Future<Result> _load() async {
+    try {
+      final result = await _bookingRepository.getBookingsList();
+      switch (result) {
+        case Ok<List<BookingSummary>>():
+          _bookings = result.value;
+          _log.fine('Loaded bookings');
+        case Error<List<BookingSummary>>():
+          _log.warning('Failed to load bookings', result.error);
+          return result;
+      }
+
+      final userResult = await _userRepository.getUser();
+      switch (userResult) {
+        case Ok<User>():
+          _user = userResult.value;
+          _log.fine('Loaded user');
+        case Error<User>():
+          _log.warning('Failed to load user', userResult.error);
+      }
+
+      return userResult;
+    } finally {
+      notifyListeners();
+    }
+  }
+
+  Future<Result<void>> _deleteBooking(int id) async {
+    try {
+      final resultDelete = await _bookingRepository.delete(id);
+      switch (resultDelete) {
+        case Ok<void>():
+          _log.fine('Deleted booking $id');
+        case Error<void>():
+          _log.warning('Failed to delete booking $id', resultDelete.error);
+          return resultDelete;
+      }
+
+      // After deleting the booking, we need to reload the bookings list.
+      // BookingRepository is the source of truth for bookings.
+      final resultLoadBookings = await _bookingRepository.getBookingsList();
+      switch (resultLoadBookings) {
+        case Ok<List<BookingSummary>>():
+          _bookings = resultLoadBookings.value;
+          _log.fine('Loaded bookings');
+        case Error<List<BookingSummary>>():
+          _log.warning('Failed to load bookings', resultLoadBookings.error);
+          return resultLoadBookings;
+      }
+
+      return resultLoadBookings;
+    } finally {
+      notifyListeners();
+    }
+  }
+}

--- a/lib/ui/home/widgets/home_screen.dart
+++ b/lib/ui/home/widgets/home_screen.dart
@@ -1,0 +1,197 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../../domain/models/booking/booking_summary.dart';
+import '../../../routing/routes.dart';
+import '../../core/localization/applocalization.dart';
+import '../../core/themes/colors.dart';
+import '../../core/themes/dimens.dart';
+import '../../core/ui/date_format_start_end.dart';
+import '../../core/ui/error_indicator.dart';
+import '../view_models/home_viewmodel.dart';
+import 'home_title.dart';
+
+const String bookingButtonKey = 'booking-button';
+
+class HomeScreen extends StatefulWidget {
+  const HomeScreen({super.key, required this.viewModel});
+
+  final HomeViewModel viewModel;
+
+  @override
+  State<HomeScreen> createState() => _HomeScreenState();
+}
+
+class _HomeScreenState extends State<HomeScreen> {
+  @override
+  void initState() {
+    super.initState();
+    widget.viewModel.deleteBooking.addListener(_onResult);
+  }
+
+  @override
+  void didUpdateWidget(covariant HomeScreen oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    oldWidget.viewModel.deleteBooking.removeListener(_onResult);
+    widget.viewModel.deleteBooking.addListener(_onResult);
+  }
+
+  @override
+  void dispose() {
+    widget.viewModel.deleteBooking.removeListener(_onResult);
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      floatingActionButton: FloatingActionButton.extended(
+        // Workaround for https://github.com/flutter/flutter/issues/115358#issuecomment-2117157419
+        heroTag: null,
+        key: const ValueKey(bookingButtonKey),
+        onPressed: () => context.go(Routes.search),
+        label: Text(AppLocalization.of(context).bookNewTrip),
+        icon: const Icon(Icons.add_location_outlined),
+      ),
+      body: SafeArea(
+        top: true,
+        bottom: true,
+        child: ListenableBuilder(
+          listenable: widget.viewModel.load,
+          builder: (context, child) {
+            if (widget.viewModel.load.running) {
+              return const Center(child: CircularProgressIndicator());
+            }
+
+            if (widget.viewModel.load.error) {
+              return ErrorIndicator(
+                title: AppLocalization.of(context).errorWhileLoadingHome,
+                label: AppLocalization.of(context).tryAgain,
+                onPressed: widget.viewModel.load.execute,
+              );
+            }
+
+            return child!;
+          },
+          child: ListenableBuilder(
+            listenable: widget.viewModel,
+            builder: (context, _) {
+              return CustomScrollView(
+                slivers: [
+                  SliverToBoxAdapter(
+                    child: Padding(
+                      padding: EdgeInsets.symmetric(
+                        vertical: Dimens.of(context).paddingScreenVertical,
+                        horizontal: Dimens.of(context).paddingScreenHorizontal,
+                      ),
+                      child: HomeHeader(viewModel: widget.viewModel),
+                    ),
+                  ),
+                  SliverList.builder(
+                    itemCount: widget.viewModel.bookings.length,
+                    itemBuilder: (_, index) => _Booking(
+                      key: ValueKey(widget.viewModel.bookings[index].id),
+                      booking: widget.viewModel.bookings[index],
+                      onTap: () => context.push(
+                        Routes.bookingWithId(
+                          widget.viewModel.bookings[index].id,
+                        ),
+                      ),
+                      confirmDismiss: (_) async {
+                        // wait for command to complete
+                        await widget.viewModel.deleteBooking.execute(
+                          widget.viewModel.bookings[index].id,
+                        );
+                        // if command completed successfully, return true
+                        if (widget.viewModel.deleteBooking.completed) {
+                          // removes the dismissable from the list
+                          return true;
+                        } else {
+                          // the dismissable stays in the list
+                          return false;
+                        }
+                      },
+                    ),
+                  ),
+                ],
+              );
+            },
+          ),
+        ),
+      ),
+    );
+  }
+
+  void _onResult() {
+    if (widget.viewModel.deleteBooking.completed) {
+      widget.viewModel.deleteBooking.clearResult();
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(AppLocalization.of(context).bookingDeleted)),
+      );
+    }
+
+    if (widget.viewModel.deleteBooking.error) {
+      widget.viewModel.deleteBooking.clearResult();
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(AppLocalization.of(context).errorWhileDeletingBooking),
+        ),
+      );
+    }
+  }
+}
+
+class _Booking extends StatelessWidget {
+  const _Booking({
+    super.key,
+    required this.booking,
+    required this.onTap,
+    required this.confirmDismiss,
+  });
+
+  final BookingSummary booking;
+  final GestureTapCallback onTap;
+  final ConfirmDismissCallback confirmDismiss;
+
+  @override
+  Widget build(BuildContext context) {
+    return Dismissible(
+      key: ValueKey(booking.id),
+      direction: DismissDirection.endToStart,
+      confirmDismiss: confirmDismiss,
+      background: Container(
+        color: AppColors.grey1,
+        child: const Row(
+          mainAxisAlignment: MainAxisAlignment.end,
+          children: [
+            Padding(
+              padding: EdgeInsets.only(right: Dimens.paddingHorizontal),
+              child: Icon(Icons.delete),
+            ),
+          ],
+        ),
+      ),
+      child: InkWell(
+        onTap: onTap,
+        child: Padding(
+          padding: EdgeInsets.symmetric(
+            horizontal: Dimens.of(context).paddingScreenHorizontal,
+            vertical: Dimens.paddingVertical,
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(booking.name, style: Theme.of(context).textTheme.titleLarge),
+              Text(
+                dateFormatStartEnd(
+                  DateTimeRange(start: booking.startDate, end: booking.endDate),
+                ),
+                style: Theme.of(context).textTheme.bodyLarge,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/utils/command.dart
+++ b/lib/utils/command.dart
@@ -1,0 +1,93 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+
+import 'result.dart';
+
+typedef CommandAction0<T> = Future<Result<T>> Function();
+typedef CommandAction1<T, A> = Future<Result<T>> Function(A);
+
+/// Facilitates interaction with a ViewModel.
+///
+/// Encapsulates an action,
+/// exposes its running and error states,
+/// and ensures that it can't be launched again until it finishes.
+///
+/// Use [Command0] for actions without arguments.
+/// Use [Command1] for actions with one argument.
+///
+/// Actions must return a [Result].
+///
+/// Consume the action result by listening to changes,
+/// then call to [clearResult] when the state is consumed.
+abstract class Command<T> extends ChangeNotifier {
+  Command();
+
+  bool _running = false;
+
+  /// True when the action is running.
+  bool get running => _running;
+
+  Result<T>? _result;
+
+  /// true if action completed with error
+  bool get error => _result is Error;
+
+  /// true if action completed successfully
+  bool get completed => _result is Ok;
+
+  /// Get last action result
+  Result? get result => _result;
+
+  /// Clear last action result
+  void clearResult() {
+    _result = null;
+    notifyListeners();
+  }
+
+  /// Internal execute implementation
+  Future<void> _execute(CommandAction0<T> action) async {
+    // Ensure the action can't launch multiple times.
+    // e.g. avoid multiple taps on button
+    if (_running) return;
+
+    // Notify listeners.
+    // e.g. button shows loading state
+    _running = true;
+    _result = null;
+    notifyListeners();
+
+    try {
+      _result = await action();
+    } finally {
+      _running = false;
+      notifyListeners();
+    }
+  }
+}
+
+/// [Command] without arguments.
+/// Takes a [CommandAction0] as action.
+class Command0<T> extends Command<T> {
+  Command0(this._action);
+
+  final CommandAction0<T> _action;
+
+  /// Executes the action.
+  Future<void> execute() async {
+    await _execute(_action);
+  }
+}
+
+/// [Command] with one argument.
+/// Takes a [CommandAction1] as action.
+class Command1<T, A> extends Command<T> {
+  Command1(this._action);
+
+  final CommandAction1<T, A> _action;
+
+  /// Executes the action with the argument.
+  Future<void> execute(A argument) async {
+    await _execute(() => _action(argument));
+  }
+}


### PR DESCRIPTION
Adds a ViewModel-driven home feature and a reusable Command utility to centralize async actions, loading/error handling, and UI feedback—improving separation of concerns and preventing concurrent action runs.

- lib/domain/models/user.dart:
  - {+} Add User model via freezed with JSON (serialization support)

- lib/ui/home/view_model/home_viewmodel.dart:
  - {+} Add HomeViewModel
    - manages bookings and user state
    - exposes load and deleteBooking commands using Result types
    - reloads bookings after deletion, logs outcomes, and notifies listeners

- lib/ui/home/widgets/home_screen.dart:
  - {+} Add HomeScreen widget
    - shows loading/error states, FAB for navigation
    - renders bookings list with Dismissible items tied to delete command
    - displays snackbars for success/error

- lib/utils/command.dart:
  - {+} Add Command abstraction (Command, Command0, Command1)
    - encapsulates running/result/error states
    - prevents reentrant execution and provides result clearing