### PR TITLE
feat(config): use platform-aware server host for API clients

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .github/
+.dart_tool/
+*.lock

--- a/app/lib/config/dependencies.dart
+++ b/app/lib/config/dependencies.dart
@@ -54,12 +54,8 @@ List<SingleChildWidget> _sharedProviders = [
 /// This dependency list uses repositories that connect to a remote server.
 List<SingleChildWidget> get providersRemote {
   return [
-    Provider(create: (context) => AuthApiClient(
-      host: _getServerHost(),
-    )),
-    Provider(create: (context) => ApiClient(
-      host: _getServerHost(),
-    )),
+    Provider(create: (context) => AuthApiClient(host: _getServerHost())),
+    Provider(create: (context) => ApiClient(host: _getServerHost())),
     Provider(create: (context) => SharedPreferencesService()),
     ChangeNotifierProvider(
       create: (context) =>

--- a/app/lib/config/dependencies.dart
+++ b/app/lib/config/dependencies.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:io';
+
 import 'package:provider/provider.dart';
 import 'package:provider/single_child_widget.dart';
 
@@ -52,8 +54,12 @@ List<SingleChildWidget> _sharedProviders = [
 /// This dependency list uses repositories that connect to a remote server.
 List<SingleChildWidget> get providersRemote {
   return [
-    Provider(create: (context) => AuthApiClient()),
-    Provider(create: (context) => ApiClient()),
+    Provider(create: (context) => AuthApiClient(
+      host: _getServerHost(),
+    )),
+    Provider(create: (context) => ApiClient(
+      host: _getServerHost(),
+    )),
     Provider(create: (context) => SharedPreferencesService()),
     ChangeNotifierProvider(
       create: (context) =>
@@ -132,4 +138,14 @@ List<SingleChildWidget> get providersLocal {
     ),
     ..._sharedProviders,
   ];
+}
+
+/// Get the appropriate server host based on the platform.
+/// Android emulators cannot access localhost directly,
+/// so we use the special IP 10.0.2.2 to access the host machine.
+String _getServerHost() {
+  if (Platform.isAndroid) {
+    return '10.0.2.2';
+  }
+  return 'localhost';
 }

--- a/server/lib/config/constants.dart
+++ b/server/lib/config/constants.dart
@@ -13,7 +13,7 @@ abstract final class Constants {
 
   /// Token to be returned on successful login.
   static const token =
-    'e1c37dfd973353b78bb71df050e2c6e72d53034e148920383968ae49b96f1fd2';
+      'e1c37dfd973353b78bb71df050e2c6e72d53034e148920383968ae49b96f1fd2';
 
   /// User id to be returned on successful login.
   static const userId = '123';


### PR DESCRIPTION
- .gitignore:
  - ignore .dart_tool/ and *.lock files

- app/lib/config/dependencies.dart:
  - import dart:io to detect runtime platform
  - add _getServerHost() helper: return 10.0.2.2 for Android, localhost for others
  - pass host to AuthApiClient and ApiClient constructors

**Platform-aware server host configuration:**
* Added the `_getServerHost()` function to return `'10.0.2.2'` for Android platforms and `'localhost'` for others, ensuring correct server connectivity during development and testing.
* Updated the providers for `AuthApiClient` and `ApiClient` to use the new `host` parameter, which is set via `_getServerHost()`.
* Imported `dart:io` to enable platform detection.


**Bug fix:**  
Login requests were failing when running with `flutter run --target lib/main_staging.dart`  
because the API client always used `localhost`. On Android emulator, this must be  
`10.0.2.2`. The new `_getServerHost()` ensures the correct host is chosen, fixing  
login for staging builds.